### PR TITLE
Sanity check

### DIFF
--- a/modules/client/package.json
+++ b/modules/client/package.json
@@ -1,7 +1,7 @@
 {
   "name": "connext",
   "description": "Shared code between wallet and hub",
-  "version": "4.2.4",
+  "version": "4.2.5",
   "main": "dist/index.js",
   "types": "types/index.d.ts",
   "devDependencies": {

--- a/modules/client/src/controllers/WithdrawalController.test.ts
+++ b/modules/client/src/controllers/WithdrawalController.test.ts
@@ -120,14 +120,14 @@ describe('WithdrawalController', () => {
         name: 'should fail if user tries to sell more tokens than they have',
       },
       {
-        args: { withdrawalTokenUser: '5' },
-        failsWith: /User token withdrawals are not permitted at this time./,
-        name: 'should fail if user tries to withdraw tokens',
+        args: { withdrawalTokenUser: '100' },
+        failsWith: /Cannot withdraw more tokens than exist in your channel./,
+        name: 'should fail if user tries to withdraw more tokens than they have',
       },
       {
-        args: { weiToSell: '5' },
-        failsWith: /User exchanging wei at withdrawal is not permitted at this time./,
-        name: 'should fail if user tries to exchange wei',
+        args: { weiToSell: '100' },
+        failsWith: /Cannot sell more wei than exist in your channel./,
+        name: 'should fail if user tries to exchange more wei than they have',
       },
     ], async ({ name, args, failsWith }: any): Promise<any> => {
       await connext.start()

--- a/modules/client/src/controllers/WithdrawalController.ts
+++ b/modules/client/src/controllers/WithdrawalController.ts
@@ -78,11 +78,11 @@ export class WithdrawalController extends AbstractController {
     }
 
     // TODO: token withdrawals
-    if (withdrawalStr.weiToSell && toBN(withdrawalStr.weiToSell).lt(channelBN.balanceWeiUser)) {
+    if (withdrawalStr.weiToSell && toBN(withdrawalStr.weiToSell).gt(channelBN.balanceWeiUser)) {
       WithdrawalError(`Cannot sell more wei than exist in your channel.`)
     }
 
-    if (withdrawalStr.withdrawalTokenUser && toBN(withdrawalStr.withdrawalTokenUser).lt(channelBN.balanceTokenUser)) {
+    if (withdrawalStr.withdrawalTokenUser && toBN(withdrawalStr.withdrawalTokenUser).gt(channelBN.balanceTokenUser)) {
       WithdrawalError(`Cannot withdraw more tokens than exist in your channel.`)
     }
 

--- a/modules/hub/package.json
+++ b/modules/hub/package.json
@@ -23,7 +23,7 @@
   "dependencies": {
     "classnames": "^2.2.5",
     "concurrently": "^4.1.0",
-    "connext": "^4.2.4",
+    "connext": "^4.2.5",
     "cors": "^2.8.5",
     "debug": "^4.1.1",
     "ethereumjs-tx": "^1.3.7",

--- a/modules/hub/src/custodial-payments/CustodialPaymentsApiService.ts
+++ b/modules/hub/src/custodial-payments/CustodialPaymentsApiService.ts
@@ -103,7 +103,7 @@ class CustodialPaymentsApiServiceHandler {
         'str',
         await this.dao.getCustodialWithdrawal(
           getAttr.address(req, 'address'),
-          getAttr(req.params, 'withdrawalId'),
+          parseInt(getAttr(req.params, 'withdrawalId'), 10),
         ),
       ),
     )

--- a/ops/deploy-client.sh
+++ b/ops/deploy-client.sh
@@ -8,7 +8,7 @@ if [[ -n "`git status -s`" ]]
 then echo "Aborting: Make sure your git repo is clean" && exit 1
 fi
 
-if [[ "`pwd | sed 's|.*/\(.*\)|\1|'`" != "indra" ]]
+if [[ ! "`pwd | sed 's|.*/\(.*\)|\1|'`" =~ "indra" ]]
 then echo "Aborting: Make sure you're in the indra project root" && exit 1
 fi
 

--- a/ops/deploy-indra.sh
+++ b/ops/deploy-indra.sh
@@ -66,3 +66,8 @@ git push origin master --no-verify
 # Push a new indra release tag
 git tag indra-$indra_version
 git push origin indra-$indra_version --no-verify
+
+# Bring staging up-to-date w master
+git checkout staging
+git merge master
+git push origin staging --no-verify

--- a/ops/test-client.sh
+++ b/ops/test-client.sh
@@ -45,7 +45,7 @@ watch_command='
 '
 
 project="`cat package.json | grep '"name":' | awk -F '"' '{print $4}'`"
-root=`pwd | sed 's/indra.*/indra/'`
+cwd=`pwd`
 if [[ "$1" == "--watch" ]]
 then
   suffix="client_watcher"
@@ -91,7 +91,7 @@ docker run \
   --name="$ETHPROVIDER_HOST" \
   --network="$NETWORK" \
   --rm \
-  --volume="$root/modules/contracts:/root" \
+  --volume="$cwd/modules/contracts:/root" \
   --tmpfs="/data" \
   ${project}_builder ops/entry.sh signal nomigrate
 
@@ -107,7 +107,7 @@ docker run \
   --network="$NETWORK" \
   --rm \
   --tty \
-  --volume=$root/modules/client:/root \
+  --volume=$cwd/modules/client:/root \
   ${project}_builder -c '
     PATH=./node_modules/.bin:$PATH
     echo "Client Tester Container launched!";echo


### PR DESCRIPTION
The legacy client tests were failing after migrating to the new repo and I reversed a few lt and gt checks to fix it which makes me a little nervous, the tests suggest that these checks were supposed to prevent certain types of withdrawals a la feature flags & I just want to confirm that these code paths should be activated.

I'll probably still merge & publish these since tests are passing and it works and it makes sense to me but wanted to bring it to your attention in case I missed something.